### PR TITLE
Return both OVS bridges and regular bridges

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox.rb
+++ b/app/models/foreman_fog_proxmox/proxmox.rb
@@ -86,7 +86,7 @@ module ForemanFogProxmox
 
     def bridges
       node = network_client.nodes.find_by_id node_name
-      bridges = node.networks.all(type: 'bridge')
+      bridges = node.networks.all(type: 'any_bridge')
       bridges.sort_by(&:iface)
     end    
 


### PR DESCRIPTION
This fixes #43, and hopefully will be forwards compatible in the event Proxmox adds support for new bridge types. 