### PR TITLE
Fix undefined method `type' if Vsphere

### DIFF
--- a/app/views/compute_resources_vms/form/proxmox/_add_vm_type_to_networks_form.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/_add_vm_type_to_networks_form.html.erb
@@ -15,7 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
 
-<% vm_type = f.object.type %>
+<% vm_type = f.object.respond_to?('type') ? f.object.type : nil %>
 
 <%= render :partial => provider_partial(compute_resource, 'network'),
               :locals => { :f => i, :vm_type => vm_type, :compute_resource => compute_resource, :new_host => new_host, :new_vm => new_vm, :remove_title => _('remove network interface') },

--- a/app/views/compute_resources_vms/form/proxmox/_add_vm_type_to_networks_new_childs_form.html.erb
+++ b/app/views/compute_resources_vms/form/proxmox/_add_vm_type_to_networks_new_childs_form.html.erb
@@ -15,7 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ForemanFogProxmox. If not, see <http://www.gnu.org/licenses/>. %>
 
-<% vm_type = f.object.type %>
+<% vm_type = f.object.respond_to?('type') ? f.object.type : nil %>
 
 <%= new_child_fields_template(f, compute_resource.interfaces_attrs_name, {
         :object => compute_resource.new_interface,


### PR DESCRIPTION
In case of using proxmox together with Vsphere, the following error
occured, if Compute Profile -> ProfileName (Small, Medium, ...) of a
Vsphere compute resource was selected:

Fix undefined method `type' for #<Fog::Compute::Vsphere::Server:0x00007fccce43e480>